### PR TITLE
Shipit integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,16 @@
     "build:compile": "babel --presets es2015 build/hotshot.js -o build/hotshot.js",
     "build:minify": "uglifyjs build/hotshot.js -o build/hotshot.min.js -c -m",
 
+    "check": "npm run lint && npm test",
+    "deploy": "npm run build && npm publish",
+    "lint": "eslint src scripts --max-warnings 0",
+
     "watch": "watch -p \"src/**/*.js\" -c \"npm run build && npm run test:copy-lib\"",
     "serve-test": "ws -p 9000 -d tests",
 
-    "test": "npm run build && npm run test:copy-lib && npm run test:unit-test && npm run test:lint",
+    "test": "npm run build && npm run test:copy-lib && npm run test:unit-test",
     "test:unit-test": "karma start",
-    "test:copy-lib": "cp build/hotshot.js tests/libs/hotshot.js",
-    "test:lint": "eslint src/ --max-warnings 0"
+    "test:copy-lib": "cp build/hotshot.js tests/libs/hotshot.js"
   },
   "eslintConfig": {
     "extends": "plugin:shopify/esnext",

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,0 +1,4 @@
+deploy:
+  override:
+    - npm install --no-progress
+    - npm run check && npm run deploy


### PR DESCRIPTION
CircleCI requires the repo's admin to set up tests, but Koen is on vacation.  Until he's back, `check` is running as part of the deploy process.  If I'm being paranoid, I can just remove that.