### PR TITLE
CircleCI + shipit integration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,23 @@
+machine:
+  environment:
+    YARN_VERSION: 0.18.1
+    PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+
+dependencies:
+  pre:
+    - |
+      if [[ ! -e ~/.yarn/bin/yarn || $(yarn --version) != "${YARN_VERSION}" ]]; then
+        echo "Download and install Yarn."
+        curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
+      else
+        echo "The correct version of Yarn is already installed."
+      fi
+  override:
+    - yarn install
+  cache_directories:
+    - ~/.yarn
+    - ~/.cache/yarn
+
+test:
+  override:
+    - yarn run check

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "build:compile": "babel --presets es2015 build/hotshot.js -o build/hotshot.js",
     "build:minify": "uglifyjs build/hotshot.js -o build/hotshot.min.js -c -m",
 
+    "check": "npm run test",
+    "prepublish": "npm run build",
+
     "watch": "watch -p \"src/**/*.js\" -c \"npm run build && npm run test:copy-lib\"",
     "serve-test": "ws -p 9000 -d tests",
 


### PR DESCRIPTION
I haven't added Yarn to `shipit`, yet, so I'm sticking with `npm` for running scripts.  It'd be possible to just run `prepublish`with `npm` and everything else with `yarn`, but I think juggling between the two could be confusing.

The `check` script is kinda redundant, but it's consistent with our general JS script naming conventions.

cc @lemonmade 